### PR TITLE
Fix trinkets integration on Fabric 1.18.2

### DIFF
--- a/src/main/java/com/tiviacz/travelersbackpack/TravelersBackpackClient.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/TravelersBackpackClient.java
@@ -8,6 +8,7 @@ import com.tiviacz.travelersbackpack.init.ModBlockEntityTypes;
 import com.tiviacz.travelersbackpack.init.ModItems;
 import com.tiviacz.travelersbackpack.init.ModScreenHandlerTypes;
 import com.tiviacz.travelersbackpack.inventory.TravelersBackpackInventory;
+import com.tiviacz.travelersbackpack.network.ModNetwork;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -41,7 +42,7 @@ public class TravelersBackpackClient implements ClientModInitializer
         }
         KeybindHandler.initKeybinds();
         KeybindHandler.registerListeners();
-
+        ModNetwork.initClient();
        // if(TravelersBackpack.enableTrinkets())
        // {
        //     TrinketsCompat.init();

--- a/src/main/java/com/tiviacz/travelersbackpack/handlers/KeybindHandler.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/handlers/KeybindHandler.java
@@ -32,14 +32,12 @@ public class KeybindHandler
         {
             ClientPlayerEntity player = evt.player;
 
-            if(player != null && ComponentUtils.isWearingBackpack(player))
-            {
-                if(OPEN_INVENTORY.wasPressed())
-                {
-                    ClientPlayNetworking.send(ModNetwork.OPEN_SCREEN_ID, PacketByteBufs.empty());
-                }
+            if(player == null) {
+                return;
             }
-
+            if (OPEN_INVENTORY.wasPressed() && ComponentUtils.isWearingBackpack(player)) {
+                ClientPlayNetworking.send(ModNetwork.OPEN_SCREEN_ID, PacketByteBufs.empty());
+            }
             if(TravelersBackpackConfig.disableScrollWheel && CYCLE_TOOL.wasPressed())
             {
                 ItemStack heldItem = player.getMainHandStack();


### PR DESCRIPTION
Please review the code, it was programmed at whim and may not contain all the checks necessary to prevent NPEs and such

```
Fix issue where pressing the key to cycle the tools would call a method from a null player

Add custom packet for config syncing from server
Load the config initially from file on both client and server, but only update client values on client
Sync server config values from server
```