### PR TITLE
Fix NBT writing to ItemStack.EMPTY

### DIFF
--- a/src/main/java/com/tiviacz/travelersbackpack/component/TravelersBackpackComponent.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/component/TravelersBackpackComponent.java
@@ -7,6 +7,7 @@ import io.netty.buffer.Unpooled;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
@@ -14,7 +15,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 
 public class TravelersBackpackComponent implements ITravelersBackpackComponent
 {
-    private ItemStack wearable = ItemStack.EMPTY;
+    private ItemStack wearable = new ItemStack(Items.AIR, 0);
     private final PlayerEntity player;
     private final TravelersBackpackInventory inventory;
 
@@ -45,8 +46,8 @@ public class TravelersBackpackComponent implements ITravelersBackpackComponent
     @Override
     public void removeWearable()
     {
-        this.wearable = ItemStack.EMPTY;
-        this.inventory.setStack(ItemStack.EMPTY);
+        this.wearable = new ItemStack(Items.AIR, 0);
+        this.inventory.setStack(new ItemStack(Items.AIR, 0));
     }
 
     @Override
@@ -110,7 +111,7 @@ public class TravelersBackpackComponent implements ITravelersBackpackComponent
         }
         if(!hasWearable())
         {
-            ItemStack wearable = ItemStack.EMPTY;
+            ItemStack wearable = new ItemStack(Items.AIR, 0);
             wearable.writeNbt(tag);
         }
     }

--- a/src/main/java/com/tiviacz/travelersbackpack/inventory/TravelersBackpackInventory.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/inventory/TravelersBackpackInventory.java
@@ -17,6 +17,7 @@ import net.fabricmc.fabric.impl.transfer.fluid.FluidVariantImpl;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventories;
+import net.minecraft.item.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
@@ -54,7 +55,7 @@ public class TravelersBackpackInventory implements ITravelersBackpackInventory
         this.player = player;
         this.stack = stack;
         this.screenID = screenID;
-
+        
         this.readAllData(stack.getOrCreateNbt());
     }
 
@@ -365,7 +366,7 @@ public class TravelersBackpackInventory implements ITravelersBackpackInventory
 
     public InventoryImproved createInventory(int size)
     {
-        return new InventoryImproved(DefaultedList.ofSize(size, ItemStack.EMPTY))
+        return new InventoryImproved(DefaultedList.ofSize(size, new ItemStack(Items.AIR, 0)))
         {
             @Override
             public void markDirty()


### PR DESCRIPTION
A quick and dirty fix for #486.

Issue is due to using the equivalent of `ItemStack.EMPTY.getOrCreateNBT()` and then writing to that NBT. All future users of `ItemStack.EMPTY` then inherit those changes. (And this lives on to other worlds so long as the client hasn't been closed.) This modification then causes packet size to increase eventually causing fallout from packets being too large.

This fix involves changing instances of `ItemStack.EMPTY` to `new ItemStack(Items.AIR, 0)`. (`ItemStack.EMPTY.copy()` doesn't seem to actually create a copy, `ItemStack.EMPTY == ItemStack.EMPTY.copy()` is `true`. Creating new `ItemStack`s rather than re-using `ItemStack.EMPTY` doesn't have much of a performance impact in this case. When saved, the stacks become independent anyway, and shifting backpacks between worn and unworn is a relatively rare event in the grand scheme of things.) This isn't the best solution, but fixing this properly would take a rewrite that changes how the backpack is worn/removed/stored on the player.