### PR TITLE
Fixed the hose when drinking potions

### DIFF
--- a/src/main/java/com/tiviacz/travelersbackpack/fluids/effects/LavaEffect.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/fluids/effects/LavaEffect.java
@@ -2,6 +2,7 @@ package com.tiviacz.travelersbackpack.fluids.effects;
 
 import com.tiviacz.travelersbackpack.fluids.EffectFluid;
 import com.tiviacz.travelersbackpack.util.Reference;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.minecraft.entity.Entity;
@@ -15,7 +16,7 @@ public class LavaEffect extends EffectFluid
 {
     public LavaEffect()
     {
-        super(Fluids.LAVA.getStill(), Reference.BUCKET);
+        super(Fluids.LAVA.getStill(), FluidConstants.BOTTLE);
     }
 
     @Override

--- a/src/main/java/com/tiviacz/travelersbackpack/fluids/effects/WaterEffect.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/fluids/effects/WaterEffect.java
@@ -2,6 +2,7 @@ package com.tiviacz.travelersbackpack.fluids.effects;
 
 import com.tiviacz.travelersbackpack.fluids.EffectFluid;
 import com.tiviacz.travelersbackpack.util.Reference;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.minecraft.entity.Entity;
@@ -17,7 +18,7 @@ public class WaterEffect extends EffectFluid
 {
     public WaterEffect()
     {
-        super(Fluids.WATER, Reference.BUCKET);
+        super(Fluids.WATER, FluidConstants.BOTTLE);
     }
 
     @Override

--- a/src/main/java/com/tiviacz/travelersbackpack/items/HoseItem.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/items/HoseItem.java
@@ -472,8 +472,8 @@ public class HoseItem extends Item
                         if(ServerActions.setFluidEffect(worldIn, player, tank))
                         {
                             try (Transaction transaction = Transaction.openOuter()) {
-                                long amountExtracted = tank.extract(tank.getResource(), FluidConstants.BUCKET, transaction);
-                                if (amountExtracted == FluidConstants.BUCKET) {
+                                long amountExtracted = tank.extract(tank.getResource(), FluidConstants.BOTTLE, transaction);
+                                if (amountExtracted == FluidConstants.BOTTLE) {
                                     transaction.commit();
                                     inv.markDataDirty(ITravelersBackpackInventory.TANKS_DATA);
                                 }


### PR DESCRIPTION
When drinking with the hose, it used 1 bucket of liquid even for potions, and when there was only 1 bottle available in the tank, it let you drink without removing the bottle of liquid in the tank. For example if you had 27000 units of potion in the tank, you were able to drink the potion, get the effect etc. but the 27000 units of potion weren't removed from the tank. And if you had 81000 units of potion or more, it removed one whole bucket (81k units) when drinking a potion (instead of only one bottle of 27000 units).