### PR TITLE
Added back capability to milk cows with hose.

### DIFF
--- a/src/main/java/com/tiviacz/travelersbackpack/TravelersBackpack.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/TravelersBackpack.java
@@ -5,6 +5,7 @@ import com.tiviacz.travelersbackpack.fluids.EffectFluidRegistry;
 import com.tiviacz.travelersbackpack.handlers.ModClientEventHandler;
 import com.tiviacz.travelersbackpack.init.*;
 import com.tiviacz.travelersbackpack.util.ResourceUtils;
+import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.InterModComms;
@@ -35,6 +36,8 @@ public class TravelersBackpack
     public TravelersBackpack()
     {
         TravelersBackpackConfig.register(ModLoadingContext.get());
+
+        ForgeMod.enableMilkFluid();
 
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::doClientStuff);

--- a/src/main/java/com/tiviacz/travelersbackpack/blockentity/TravelersBackpackBlockEntity.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/blockentity/TravelersBackpackBlockEntity.java
@@ -38,11 +38,10 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BedPart;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.templates.FluidTank;
-import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.wrapper.RangedWrapper;
@@ -666,7 +665,7 @@ public class TravelersBackpackBlockEntity extends BlockEntity implements ITravel
     public <T> LazyOptional<T> getCapability(@Nonnull final Capability<T> cap, @Nullable final Direction side)
     {
         Direction direction = getBlockDirection(this);
-        if(cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+        if(cap == ForgeCapabilities.ITEM_HANDLER)
         {
             if(side == null)
             {
@@ -684,7 +683,7 @@ public class TravelersBackpackBlockEntity extends BlockEntity implements ITravel
                     if(side == direction || side == direction.getOpposite()) return craftingInventoryCapability.cast();
             }
         }
-        if(cap == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY)
+        if(cap == ForgeCapabilities.FLUID_HANDLER)
         {
             if(side == null)
             {


### PR DESCRIPTION
Fixed use of deprecated methods from forge.
You can now milk cows directly with the hose.
Enabled forge milk fluid as default for this to work.
Moved a bit of code around in ItemHose for filling tanks to avoid duplications.