### PR TITLE
Fix ConcurrentModificationException of ItemProperties#PROPERTIES caused by calling ItemProperties#register in the Client Setup phase

### DIFF
--- a/src/main/java/com/tiviacz/travelersbackpack/TravelersBackpack.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/TravelersBackpack.java
@@ -94,8 +94,10 @@ public class TravelersBackpack {
     }
 
     private void doClientStuff(final FMLClientSetupEvent event) {
-        ModClientEventHandler.registerBlockEntityRenderers();
-        ModClientEventHandler.registerItemModelProperties();
+        event.enqueueWork(() -> {
+            ModClientEventHandler.registerBlockEntityRenderers();
+            ModClientEventHandler.registerItemModelProperties();
+        });
         if(accessoriesLoaded) TravelersBackpackAccessory.initClient();
         if(curiosLoaded && !accessoriesLoaded) TravelersBackpackCurio.registerCurioRenderer();
     }


### PR DESCRIPTION
Full crash info: [minecraft-exported-crash-info-2025-01-02T22-27-51(1).zip](https://github.com/user-attachments/files/18302339/minecraft-exported-crash-info-2025-01-02T22-27-51.1.zip)
I used [this project](https://github.com/Viola-Siemens/CME-Suck-My-Duck) to troubleshoot and found that your mod conflicts with avaritia and musketmod. Please see CMESuckMyDuck.log for details.