### PR TITLE
Fix crash on server disconnect: guard config access with isLoaded() check

### DIFF
--- a/src/main/java/com/tiviacz/travelersbackpack/TravelersBackpack.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/TravelersBackpack.java
@@ -133,11 +133,11 @@ public class TravelersBackpack implements ModInitializer {
     }
 
     public static boolean enableAccessories() {
-        return accessoriesLoaded && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
+        return accessoriesLoaded && TravelersBackpackConfig.serverSpec.isLoaded() && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
     }
 
     public static boolean enableTrinkets() {
-        return trinketsLoaded && !enableAccessories() && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
+        return trinketsLoaded && !enableAccessories() && TravelersBackpackConfig.serverSpec.isLoaded() && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
     }
 
     public static boolean isAnyGraveModInstalled() {


### PR DESCRIPTION
## Bug

Both clients crash when a multiplayer server stops normally (e.g. pressing the Stop button in the server manager). The crash occurs on the **render thread**, triggered during the 1-2 frames Minecraft continues rendering after receiving the disconnect packet.

**Stack trace (abbreviated):**
```
java.lang.IllegalStateException: Cannot get config value before config is loaded.
    at net.neoforged.neoforge.common.ModConfigSpec$ConfigValue.get(ModConfigSpec.java:1199)
    at com.tiviacz.travelersbackpack.TravelersBackpack.enableTrinkets(TravelersBackpack.java:140)
    at com.tiviacz.travelersbackpack.TravelersBackpack.enableIntegration(TravelersBackpack.java:132)
    at com.tiviacz.travelersbackpack.attachment.AttachmentUtils.getWearingBackpack(AttachmentUtils.java:56)
    at com.tiviacz.travelersbackpack.client.screens.HudOverlay.renderOverlay(HudOverlay.java:31)
```

Two distinct crash paths were observed across two clients on the same session:
- **Entity renderer path:** HumanoidMobRenderer mixin ? AttachmentUtils.getWearingBackpack ? enableTrinkets()
- **HUD path:** HudOverlay.renderOverlay ? AttachmentUtils.isWearingBackpack ? enableTrinkets()

## Root Cause

When the server stops, orgeconfigapiport fires the NeoForge server lifecycle events, which unloads the SERVER-typed config (ModConfigSpec clears its childConfig, causing isLoaded() to return alse). However, the render thread continues executing frames during the teardown transition. Any call into enableTrinkets() or enableAccessories() at this point calls ModConfigSpec.get() on an unloaded spec, which throws IllegalStateException.

## Fix

Add an isLoaded() guard in enableAccessories() and enableTrinkets() before calling .get(). When the config is not loaded, both methods short-circuit to alse, which causes enableIntegration() to return alse - the correct behavior during teardown.

isLoaded() is already used elsewhere in this codebase (TravelersBackpackConfig.java:651), so this is consistent with existing patterns.

**Changed:** TravelersBackpack.java - two one-line additions, no behavior change when config is loaded normally.

`java
// Before
public static boolean enableAccessories() {
    return accessoriesLoaded && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
}
public static boolean enableTrinkets() {
    return trinketsLoaded && !enableAccessories() && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
}

// After
public static boolean enableAccessories() {
    return accessoriesLoaded && TravelersBackpackConfig.serverSpec.isLoaded() && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
}
public static boolean enableTrinkets() {
    return trinketsLoaded && !enableAccessories() && TravelersBackpackConfig.serverSpec.isLoaded() && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
}
`

Tested on Fabric 26.1.2 with 	rinkets_updated and orgeconfigapiport installed. Server can now be stopped cleanly without crashing connected clients.