### PR TITLE
Fix issue where the sleeping bag cannot be deployed after passing through the Nether portal

### DIFF
--- a/src/main/java/com/tiviacz/travelersbackpack/client/screens/buttons/SleepingBagButton.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/client/screens/buttons/SleepingBagButton.java
@@ -3,9 +3,12 @@ package com.tiviacz.travelersbackpack.client.screens.buttons;
 import com.tiviacz.travelersbackpack.client.screens.BackpackScreen;
 import com.tiviacz.travelersbackpack.network.ServerboundActionTagPacket;
 import com.tiviacz.travelersbackpack.util.KeyHelper;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +43,10 @@ public class SleepingBagButton extends Button {
             if(this.isEquipped && screen.getWrapper().getBackpackOwner() == null) {
                 return false;
             }
-            ServerboundActionTagPacket.create(ServerboundActionTagPacket.SLEEPING_BAG, this.isEquipped ? screen.getWrapper().getBackpackOwner().blockPosition() : screen.getWrapper().getBackpackPos(), this.isEquipped, KeyHelper.isShiftPressed());
+
+            Level level = Minecraft.getInstance().level;
+            BlockPos pos = this.isEquipped ? screen.getWrapper().getBackpackOwner(level).blockPosition() : screen.getWrapper().getBackpackPos();
+            ServerboundActionTagPacket.create(ServerboundActionTagPacket.SLEEPING_BAG, pos, this.isEquipped, KeyHelper.isShiftPressed());
             return true;
         }
         return false;

--- a/src/main/java/com/tiviacz/travelersbackpack/inventory/BackpackWrapper.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/inventory/BackpackWrapper.java
@@ -50,6 +50,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
@@ -64,7 +65,7 @@ public class BackpackWrapper {
     public ItemStackHandler upgradesTracker;
 
     private final UpgradeManager upgradeManager;
-    private Player owner;
+    private UUID ownerUUID;
     public ArrayList<Player> playersUsing = new ArrayList<>();
     protected Level level;
     private final int screenID;
@@ -156,12 +157,23 @@ public class BackpackWrapper {
     }
 
     public void setBackpackOwner(Player player) {
-        this.owner = player;
+        this.ownerUUID = player.getUUID();
     }
 
     @Nullable
     public Player getBackpackOwner() {
-        return this.owner;
+        // on client side, this.level reference will become stale
+        // on level change event (e.g. passing through a portal)
+        // TODO either don't cache the level reference or invalidate it
+        return this.getBackpackOwner(this.level);
+    }
+
+    public Player getBackpackOwner(Level level) {
+        try {
+            return level.getPlayerByUUID(this.ownerUUID);
+        } catch (NullPointerException e) {
+            return null;
+        }
     }
 
     public ArrayList<Player> getPlayersUsing() {


### PR DESCRIPTION
Fix for #1558

- Remove cached Player object from BackpackWrapper
- Cache backpack owner UUID instead of Player object
- Avoid using player coordinates from possibly stale cached Level object on client side
- Fix issue where the sleeping bag cannot be deployed after passing through the Nether portal