### PR TITLE
Fix config access during 1.21.11 integration teardown

### DIFF
--- a/src/main/java/com/tiviacz/travelersbackpack/TravelersBackpack.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/TravelersBackpack.java
@@ -134,11 +134,11 @@ public class TravelersBackpack implements ModInitializer {
     }
 
     public static boolean enableAccessories() {
-        return accessoriesLoaded && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
+        return accessoriesLoaded && TravelersBackpackConfig.serverSpec.isLoaded() && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
     }
 
     public static boolean enableTrinkets() {
-        return trinketsLoaded && !enableAccessories() && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
+        return trinketsLoaded && !enableAccessories() && TravelersBackpackConfig.serverSpec.isLoaded() && TravelersBackpackConfig.SERVER.backpackSettings.backSlotIntegration.get();
     }
 
     public static boolean isAnyGraveModInstalled() {


### PR DESCRIPTION
### Summary
- Guard server-config reads in `enableAccessories()` and `enableTrinkets()`.
- Prevent `IllegalStateException: Cannot get config value before config is loaded.` when client-side backpack rendering runs while a server config is unloading.
- Backport the load-state guard from #1551, which was merged only into `26.1-fabric`.

### Validation
- `bash ./gradlew --no-daemon remapJar`
- Reproduced the disconnect/config-teardown path on Fabric 1.21.11; the guarded build completes it without the original client crash.

This intentionally contains no unrelated 26.1 changes.