### PR TITLE
Fix Ctrl+Q crash in backpack crafting result slot

### DIFF
--- a/src/main/java/com/tiviacz/travelersbackpack/inventory/menu/slot/ResultSlotExt.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/inventory/menu/slot/ResultSlotExt.java
@@ -120,7 +120,7 @@ public class ResultSlotExt extends ResultSlot {
 
     @Override
     public ItemStack safeTake(int amount, int maxAmount, Player player) {
-        if(player.level().isClientSide()) {
+        if (player.level().isClientSide()) {
             return ItemStack.EMPTY;
         }
         return super.safeTake(amount, maxAmount, player);

--- a/src/main/java/com/tiviacz/travelersbackpack/inventory/menu/slot/ResultSlotExt.java
+++ b/src/main/java/com/tiviacz/travelersbackpack/inventory/menu/slot/ResultSlotExt.java
@@ -117,4 +117,12 @@ public class ResultSlotExt extends ResultSlot {
         }
         return ItemStack.EMPTY;
     }
+
+    @Override
+    public ItemStack safeTake(int amount, int maxAmount, Player player) {
+        if(player.level().isClientSide()) {
+            return ItemStack.EMPTY;
+        }
+        return super.safeTake(amount, maxAmount, player);
+    }
 }


### PR DESCRIPTION
Fixes the client freeze/crash caused by pressing Ctrl+Q on the backpack crafting result slot.

The custom result slot returned a copied item client-side without allowing the throw-all loop to terminate. This change returns an empty stack from `safeTake` on the client.

Tested on Fabric 26.1.2:

- Ctrl+Q no longer freezes or crashes the client
- crafting ingredients are consumed once
- no item duplication or item loss
- normal clicking and Q behavior still work

Fixes #1562.
Related to #1489.